### PR TITLE
stop_oncomplete_calling_on_forcestop_of_tween_if_already_completed

### DIFF
--- a/Assets/FlowEnt/Scripts/Runtime/Core/Abstract/AbstractAnimation/AbstractAnimation.cs
+++ b/Assets/FlowEnt/Scripts/Runtime/Core/Abstract/AbstractAnimation/AbstractAnimation.cs
@@ -180,8 +180,9 @@ namespace FriedSynapse.FlowEnt
             switch (playState)
             {
                 case PlayState.Building:
-                case PlayState.Finished:
                     break;
+                case PlayState.Finished:
+                    return;
                 case PlayState.Waiting:
                     if (startHelper != null)
                     {


### PR DESCRIPTION
fix: if the abstract animation is already finished no need to do anything so just return out of the function.

`MyAnimation?.Stop(true);` with an oncomplete function and stop it after it has finished playing.